### PR TITLE
Bugfix - see https://github.com/7kfpun/flag-css/issues/5

### DIFF
--- a/dist/scss/flag-list.scss
+++ b/dist/scss/flag-list.scss
@@ -20,18 +20,18 @@
  * OR OTHER DEALINGS IN THE SOFTWARE.
  */
 @mixin flag($alpha3, $alpha2, $numeric, $ioc: null, $fifa: null) {
-  @if $ioc = null and $fifa = null {
+  @if $ioc == null and $fifa == null {
     .flag-#{$alpha3}, .flag-#{$alpha2}, .flag-#{$numeric} {
       background-image: unquote("url(#{$flag-css-png-path}/#{$alpha3}.png)");
       background-image: unquote("url(#{$flag-css-path}/#{$alpha3}.svg)");
     }
   }
-  @else if $ioc != null and $fifa = null {
+  @else if $ioc != null and $fifa == null {
     .flag-#{$alpha3}, .flag-#{$alpha2}, .flag-#{$numeric}, .flag-ioc-#{$ioc} {
       background-image: unquote("url(#{$flag-css-png-path}/#{$alpha3}.png)");
       background-image: unquote("url(#{$flag-css-path}/#{$alpha3}.svg)");
     }
-  } @else if $ioc = null and $fifa = null {
+  } @else if $ioc == null and $fifa == null {
     .flag-#{$alpha3}, .flag-#{$alpha2}, .flag-#{$numeric}, .flag-fifa-#{$fifa} {
       background-image: unquote("url(#{$flag-css-png-path}/#{$alpha3}.png)");
       background-image: unquote("url(#{$flag-css-path}/#{$alpha3}.svg)");
@@ -50,7 +50,7 @@
 @include flag(aia, ai, 660, aia, aia);
 @include flag(ala, ax, 248, null, ald);
 @include flag(alb, al, 8, alb, alb);
-@include flag(and, ad, 20, and, and);
+@include flag('and', ad, 20, 'and', 'and');
 @include flag(are, ae, 784, uae, uae);
 @include flag(arg, ar, 32, arg, arg);
 @include flag(arm, am, 51, arm, arm);
@@ -238,7 +238,7 @@
 @include flag(sau, sa, 682, ksa, ksa);
 @include flag(sdn, sd, 729, sud, sud);
 @include flag(sen, sn, 686, sen, sen);
-@include flag(sgp, sg, 702, sin, sin);
+@include flag(sgp, sg, 702, 'sin', 'sin');
 @include flag(sgs, gs, 239, null, null);
 @include flag(shn, sh, 654, hel, shn);
 @include flag(sjm, sj, 744, null, null);
@@ -273,7 +273,7 @@
 @include flag(tur, tr, 792, tur, tur);
 @include flag(tuv, tv, 798, tuv, tuv);
 @include flag(twn, tw, 158, null, null);
-@include flag(tza, tz, 834, tan, tan);
+@include flag(tza, tz, 834, 'tan', 'tan');
 @include flag(uga, ug, 800, uga, uga);
 @include flag(ukr, ua, 804, ukr, ukr);
 @include flag(umi, um, 581, null, null);


### PR DESCRIPTION
- `=`  changed to `==` in all `@if` conditionals
- instances of `and`,`sin` and `tan`, have been quoted in `@include` args.

node-sass no longer throwing errors for me.
Perhaps all string values should be quoted in the `@include` args?
